### PR TITLE
fix url parse for cors

### DIFF
--- a/middlewares/07-cors.js
+++ b/middlewares/07-cors.js
@@ -11,7 +11,7 @@ module.exports = function* (next) {
   }
 
   let origin = url.parse(this.get('Origin'));
-  this.set('Access-Control-Allow-Origin', origin.hostname);
+  this.set('Access-Control-Allow-Origin', origin.protocol + '//' + origin.hostname);
   this.set('Access-Control-Allow-Credentials', 'true');
 
   yield* next;


### PR DESCRIPTION
Сервер в заголовке не отдаёт полный путь в заголовке Access-Control-Allow-Origin, поэтому cors не работает. Добавил протокол к заголовку.
